### PR TITLE
feat: add query helpers and logging improvements

### DIFF
--- a/__tests__/apply-query.spec.ts
+++ b/__tests__/apply-query.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { applyODataQuery } from "../src/core/apply-query";
+import { createODataResponse } from "../src/middleware/response";
+import { createODataLogger } from "../src/middleware/logger";
+import type { ODataMiddlewareContext } from "../src/middleware/types";
+import type { ODataQueryOptions, EdmModel } from "../src/core/types";
+
+interface Person {
+  id: number;
+  name: string;
+  age: number;
+}
+
+describe("applyODataQuery helper", () => {
+  it("applies filter, ordering, pagination and selection similar to ODataQueryOptions.ApplyTo", () => {
+    const people: Person[] = [
+      { id: 1, name: "Alice", age: 30 },
+      { id: 2, name: "Bob", age: 20 },
+      { id: 3, name: "Charlie", age: 16 },
+    ];
+
+    const options: ODataQueryOptions = {
+      filter: "age ge 18",
+      orderby: [{ property: "age", direction: "desc" }],
+      skip: 1,
+      top: 1,
+      select: ["name"],
+      count: true,
+    };
+
+    const result = applyODataQuery(people, options);
+
+    expect(result.value).toEqual([{ name: "Bob" }]);
+    expect(result.count).toBe(2);
+  });
+});
+
+describe("createODataResponse helper", () => {
+  it("builds an OData-compliant collection response", () => {
+    const options: ODataQueryOptions = {
+      filter: "age ge 18",
+      orderby: [{ property: "age", direction: "desc" }],
+      skip: 1,
+      top: 1,
+      select: ["name"],
+      count: true,
+    };
+
+    const context: ODataMiddlewareContext = {
+      model: { entityTypes: [], entitySets: [] } as unknown as EdmModel,
+      serviceRoot: "https://api.example.com/odata",
+      entitySet: "People",
+      options,
+      logger: createODataLogger({ level: "silent" }),
+    };
+
+    const data = [{ name: "Bob" }];
+    const response = createODataResponse(context, { value: data, count: 2 });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["Content-Type"]).toBe("application/json");
+    expect(response.headers["OData-Version"]).toBe("4.01");
+
+    const payload = JSON.parse(response.body) as Record<string, unknown>;
+    expect(payload["@odata.context"]).toBe("https://api.example.com/odata/$metadata#People");
+    expect(payload["@odata.count"]).toBe(2);
+    expect(payload.value).toEqual(data);
+  });
+});

--- a/src/core/apply-query.ts
+++ b/src/core/apply-query.ts
@@ -1,0 +1,41 @@
+import { filterArray, orderArray, paginateArray } from "./filter-order";
+import { expandData, projectArray } from "./shape";
+import type { ODataEntity, ODataQueryOptions } from "./types";
+
+export interface ApplyODataQuerySettings {
+  includeCount?: boolean;
+}
+
+export interface ApplyODataQueryResult<T extends ODataEntity> {
+  value: Partial<T>[];
+  count?: number;
+}
+
+export function applyODataQuery<T extends ODataEntity>(
+  data: T[],
+  options: ODataQueryOptions,
+  settings: ApplyODataQuerySettings = {},
+): ApplyODataQueryResult<T> {
+  const includeCount = settings.includeCount ?? Boolean(options.count);
+
+  let workingSet = Array.isArray(data) ? [...data] : [];
+  workingSet = filterArray(workingSet, options);
+
+  let totalCount: number | undefined;
+  if (includeCount) {
+    totalCount = workingSet.length;
+  }
+
+  workingSet = orderArray(workingSet, options);
+  workingSet = paginateArray(workingSet, options);
+
+  const expanded = expandData(workingSet, options);
+  const projected = Array.isArray(expanded)
+    ? projectArray(expanded as T[], options)
+    : projectArray([expanded as T], options);
+
+  return {
+    value: projected,
+    count: includeCount ? totalCount ?? projected.length : undefined,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,10 @@ export {
 
 // Composition utilities
 export { composeMiddlewares } from "./middleware/compose";
+export { createODataResponse } from "./middleware/response";
+export type { CreateODataResponseOptions } from "./middleware/response";
+export { createODataLogger, deriveLogger } from "./middleware/logger";
+export type { ODataLogger, ODataLogLevel } from "./middleware/logger";
 
 // Middleware types and interfaces
 export type {
@@ -74,3 +78,5 @@ export {
 } from "./core/conformance-levels";
 export * from "./core/format-serialization";
 export * from "./core/search-compute-apply";
+export { applyODataQuery } from "./core/apply-query";
+export type { ApplyODataQueryResult, ApplyODataQuerySettings } from "./core/apply-query";

--- a/src/middleware/compose.ts
+++ b/src/middleware/compose.ts
@@ -1,7 +1,5 @@
-import type { MiddlewareObj } from "@middy/core";
-// Removed unused imports
-
-declare const console: any;
+import type { MiddlewareObj, Request } from "@middy/core";
+import type { ODataMiddlewareContext } from "./types";
 
 
 /**
@@ -95,8 +93,14 @@ export function mergeMiddlewareOptions<T extends Record<string, unknown>>(
  * @param request Middy request object
  * @returns OData middleware context
  */
-export function getMiddlewareContext(request: any): any {
-  return request.internal?.odata || {};
+export function getMiddlewareContext(
+  request: Request & { odata?: ODataMiddlewareContext },
+): ODataMiddlewareContext {
+  const internal = request.internal as (Record<string, unknown> & {
+    odata?: ODataMiddlewareContext;
+  }) | undefined;
+
+  return request.odata ?? internal?.odata ?? ({} as ODataMiddlewareContext);
 }
 
 /**
@@ -104,7 +108,14 @@ export function getMiddlewareContext(request: any): any {
  * @param request Middy request object
  * @param context OData middleware context
  */
-export function setMiddlewareContext(request: any, context: any): void {
-  request.internal = request.internal || {};
-  request.internal.odata = context;
+export function setMiddlewareContext(
+  request: Request & { odata?: ODataMiddlewareContext },
+  context: ODataMiddlewareContext,
+): void {
+  const internal = (request.internal || {}) as Record<string, unknown> & {
+    odata?: ODataMiddlewareContext;
+  };
+  internal.odata = context;
+  request.internal = internal;
+  request.odata = context;
 }

--- a/src/middleware/conformance.ts
+++ b/src/middleware/conformance.ts
@@ -78,17 +78,19 @@ export function odataConformance(options: Partial<ODataConformanceOptions> = {})
         }
 
         // Add conformance level information to response headers
-        if (context.metadata?.conformance) {
+        const conformanceMeta = context.metadata?.conformance as { level?: string } | undefined;
+
+        if (conformanceMeta?.level) {
           const headers = request.response.headers || {};
-          
+
           // Add OData conformance header
-          headers["OData-Conformance"] = context.metadata.conformance.level;
-          
+          headers["OData-Conformance"] = conformanceMeta.level;
+
           // Add supported conformance levels
           headers["OData-Supported-Conformance"] = "minimal,intermediate,advanced";
-          
+
           // Add feature availability based on conformance level
-          const features = getAvailableFeatures(context.metadata.conformance.level);
+          const features = getAvailableFeatures(conformanceMeta.level);
           if (features.length > 0) {
             headers["OData-Features"] = features.join(",");
           }

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -1,0 +1,77 @@
+export type ODataLogLevel = "silent" | "error" | "warn" | "info" | "debug";
+
+export interface ODataLogger {
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+export interface CreateODataLoggerOptions {
+  level?: ODataLogLevel;
+  logger?: Partial<ODataLogger> | ODataLogger;
+  prefix?: string;
+}
+
+const LEVEL_PRIORITY: Record<ODataLogLevel, number> = {
+  silent: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  debug: 4,
+};
+
+const NOOP = () => {};
+
+function resolveLoggerMethod(
+  logger: Partial<ODataLogger> | ODataLogger | undefined,
+  method: keyof ODataLogger,
+): (...args: unknown[]) => void {
+  if (logger && typeof (logger as ODataLogger)[method] === "function") {
+    return ((logger as ODataLogger)[method] as (...args: unknown[]) => void).bind(logger);
+  }
+
+  const fallbackConsole = typeof console !== "undefined" ? console : undefined;
+  const fallback = fallbackConsole?.[method] ?? fallbackConsole?.log;
+  return typeof fallback === "function" ? fallback.bind(fallbackConsole) : NOOP;
+}
+
+function wrapWithPrefix(
+  method: (...args: unknown[]) => void,
+  prefix?: string,
+): (...args: unknown[]) => void {
+  if (!prefix) {
+    return method;
+  }
+  return (...args: unknown[]) => method(prefix, ...args);
+}
+
+export function createODataLogger(options: CreateODataLoggerOptions = {}): ODataLogger {
+  const { level = "warn", logger, prefix } = options;
+  const debugTarget = wrapWithPrefix(resolveLoggerMethod(logger, "debug"), prefix);
+  const infoTarget = wrapWithPrefix(resolveLoggerMethod(logger, "info"), prefix);
+  const warnTarget = wrapWithPrefix(resolveLoggerMethod(logger, "warn"), prefix);
+  const errorTarget = wrapWithPrefix(resolveLoggerMethod(logger, "error"), prefix);
+
+  const currentLevel = LEVEL_PRIORITY[level] ?? LEVEL_PRIORITY.warn;
+
+  return {
+    debug: currentLevel >= LEVEL_PRIORITY.debug ? debugTarget : NOOP,
+    info: currentLevel >= LEVEL_PRIORITY.info ? infoTarget : NOOP,
+    warn: currentLevel >= LEVEL_PRIORITY.warn ? warnTarget : NOOP,
+    error: currentLevel >= LEVEL_PRIORITY.error ? errorTarget : NOOP,
+  };
+}
+
+export function deriveLogger(base: ODataLogger | undefined, prefix: string): ODataLogger {
+  if (!base) {
+    return createODataLogger({ level: "warn", prefix });
+  }
+
+  return {
+    debug: (...args: unknown[]) => base.debug(prefix, ...args),
+    info: (...args: unknown[]) => base.info(prefix, ...args),
+    warn: (...args: unknown[]) => base.warn(prefix, ...args),
+    error: (...args: unknown[]) => base.error(prefix, ...args),
+  };
+}

--- a/src/middleware/middy-augmentation.d.ts
+++ b/src/middleware/middy-augmentation.d.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+import type { ODataMiddlewareContext } from "./types";
+
+declare module "@middy/core" {
+  interface Request<
+    TEvent = any,
+    TResult = any,
+    TErr = Error,
+    TContext = any,
+    TInternal extends Record<string, unknown> = {},
+  > {
+    odata?: ODataMiddlewareContext;
+  }
+}

--- a/src/middleware/parse.ts
+++ b/src/middleware/parse.ts
@@ -3,6 +3,7 @@ import type { ODataParseOptions, ODataMiddlewareContext } from "./types";
 import type { EdmModel } from "../core/types";
 import { parseODataQuery } from "../core/parse";
 import { mergeMiddlewareOptions, setMiddlewareContext } from "./compose";
+import { createODataLogger } from "./logger";
 
 const DEFAULT_PARSE_OPTIONS: ODataParseOptions = {
   model: {} as any, // Will be provided by user
@@ -22,6 +23,7 @@ const DEFAULT_PARSE_OPTIONS: ODataParseOptions = {
  */
 export function odataParse(options: Partial<ODataParseOptions> = {}): MiddlewareObj {
   const opts = mergeMiddlewareOptions(DEFAULT_PARSE_OPTIONS, options);
+  const logger = opts.logger ?? createODataLogger({ level: opts.logLevel, prefix: "[OData]" });
 
   return {
     before: async (request: any) => {
@@ -47,6 +49,7 @@ export function odataParse(options: Partial<ODataParseOptions> = {}): Middleware
           serviceRoot,
           entitySet: undefined, // Will be set by route handler or other middleware
           options: parsedOptions,
+          logger,
           runtime: {
             dataCache: new Map(),
           },
@@ -69,12 +72,13 @@ export function odataParse(options: Partial<ODataParseOptions> = {}): Middleware
         // The error middleware will handle the actual error
         const context: ODataMiddlewareContext = {
           model: opts.model as EdmModel,
-          serviceRoot: typeof opts.serviceRoot === "function" 
-            ? opts.serviceRoot(request.event) 
+          serviceRoot: typeof opts.serviceRoot === "function"
+            ? opts.serviceRoot(request.event)
             : opts.serviceRoot,
           entitySet: undefined,
           options: {},
           error: error as Error,
+          logger,
           runtime: {
             dataCache: new Map(),
           },

--- a/src/middleware/response.ts
+++ b/src/middleware/response.ts
@@ -1,0 +1,92 @@
+import type { ODataMiddlewareContext } from "./types";
+import type { ApplyODataQueryResult } from "../core/apply-query";
+import type { ODataEntity } from "../core/types";
+
+export interface CreateODataResponseOptions {
+  statusCode?: number;
+  headers?: Record<string, string>;
+  includeContext?: boolean;
+  includeCount?: boolean;
+  contextUrl?: string;
+  nextLink?: string;
+  additionalProperties?: Record<string, unknown>;
+}
+
+interface NormalizedResult<T extends ODataEntity> {
+  value: Partial<T>[];
+  count?: number;
+}
+
+export function createODataResponse<T extends ODataEntity>(
+  context: ODataMiddlewareContext,
+  result: ApplyODataQueryResult<T> | Partial<T>[] | T[],
+  options: CreateODataResponseOptions = {},
+): {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+} {
+  const {
+    statusCode = 200,
+    headers = {},
+    includeContext = true,
+    includeCount = true,
+    contextUrl,
+    nextLink,
+    additionalProperties = {},
+  } = options;
+
+  const normalized = normalizeResult(result);
+
+  const payload: Record<string, unknown> = {
+    value: normalized.value,
+    ...additionalProperties,
+  };
+
+  if (includeContext) {
+    payload["@odata.context"] = contextUrl ?? buildContextUrl(context);
+  }
+
+  const shouldIncludeCount = includeCount && (context.options?.count || normalized.count !== undefined);
+  if (shouldIncludeCount) {
+    payload["@odata.count"] = normalized.count ?? normalized.value.length;
+  }
+
+  if (nextLink) {
+    payload["@odata.nextLink"] = nextLink;
+  }
+
+  return {
+    statusCode,
+    headers: {
+      "Content-Type": "application/json",
+      "OData-Version": "4.01",
+      ...headers,
+    },
+    body: JSON.stringify(payload),
+  };
+}
+
+function normalizeResult<T extends ODataEntity>(
+  result: ApplyODataQueryResult<T> | Partial<T>[] | T[],
+): NormalizedResult<T> {
+  if (Array.isArray(result)) {
+    return { value: result as Partial<T>[] };
+  }
+
+  return {
+    value: result.value,
+    count: result.count,
+  };
+}
+
+function buildContextUrl(context: ODataMiddlewareContext): string {
+  const serviceRoot = (context.serviceRoot ?? "").replace(/\/+$/u, "");
+  const entitySet = context.entitySet?.replace(/^\/+/, "");
+
+  if (entitySet) {
+    return `${serviceRoot}/$metadata#${entitySet}`;
+  }
+
+  return `${serviceRoot}/$metadata`;
+}

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareObj } from "@middy/core";
 import type { EdmModel, ODataQueryOptions } from "../core/types";
+import type { ODataLogger, ODataLogLevel } from "./logger";
 
 // Base middleware context that all OData middlewares will use
 export interface ODataMiddlewareContext {
@@ -16,6 +17,7 @@ export interface ODataMiddlewareContext {
   runtime?: {
     dataCache?: Map<string, unknown[]>;
   };
+  logger?: ODataLogger;
   // Metadata for debugging and logging
   metadata?: {
     executionTime?: number;
@@ -31,6 +33,8 @@ export interface ODataParseOptions {
   serviceRoot: string | ((event: any) => string);
   validateAgainstModel?: boolean;
   strictMode?: boolean;
+  logger?: ODataLogger;
+  logLevel?: ODataLogLevel;
   [key: string]: unknown;
 }
 
@@ -114,6 +118,7 @@ export interface ODataRoutingOptions {
   dataProviders?: Record<string, () => Promise<unknown[]> | unknown[]>;
   enableRouting?: boolean;
   strictMode?: boolean;
+  logger?: ODataLogger;
   [key: string]: unknown;
 }
 
@@ -131,6 +136,8 @@ export interface ODataOptions {
   metadata?: Partial<ODataMetadataOptions>;
   conformance?: Partial<ODataConformanceOptions>;
   routing?: Partial<ODataRoutingOptions>;
+  logger?: Partial<ODataLogger> | ODataLogger;
+  logLevel?: ODataLogLevel;
   // Legacy options for backward compatibility
   enable?: {
     parse?: boolean;


### PR DESCRIPTION
## Summary
- add logger utilities and propagate logLevel/logger options through the OData context
- expose applyODataQuery and createODataResponse helpers and document typed request access
- add coverage for the new helpers with targeted unit tests

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb63e23e483229f10cbf6e458d497